### PR TITLE
Fix Hugo v0.146.0 compatibility issues

### DIFF
--- a/content/posts/best-job-hunting-resources/index.md
+++ b/content/posts/best-job-hunting-resources/index.md
@@ -34,7 +34,7 @@ In order to capture your true worth you need to think about how you respond to q
 
 If you ever doubt your true worth, remember that the following is true:
 
-{{< tweet user="JordanKobi" id="1570561685018247168" >}}
+{{< x user="JordanKobi" id="1570561685018247168" >}}
 
 ## Behavioral Question Prep
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -4,11 +4,12 @@ title = 'Tzvi.dev'
 theme = "hugo-coder"
 defaultcontentlanguage = "en"
 
-paginate = 20
-
 disqusShortname = "www-tzvi-dev"
 googleAnalytics = 'G-8VNBN2DTFH'
 enableEmoji = true
+
+[pagination]
+pagerSize = 20
 
 [markup.highlight]
 style = "github-dark"


### PR DESCRIPTION
## Summary
Fixes build errors introduced by Hugo v0.146.0:
- Replaced deprecated `paginate` config with `pagination.pagerSize`
- Updated `tweet` shortcode to `x` shortcode (Twitter → X rebranding)

## Changes
- **hugo.toml**: Moved `paginate = 20` to `[pagination]` section with `pagerSize = 20`
- **content/posts/best-job-hunting-resources/index.md**: Changed `{{< tweet >}}` to `{{< x >}}`

## Why
Hugo v0.128.0 deprecated the `paginate` config key and v0.146.0 enforces this, causing build failures. Similarly, Twitter-related shortcodes were deprecated in v0.142.0 and removed in v0.156.0.

## Test plan
- [x] Local build successful with Hugo v0.157.0
- [x] No deprecation warnings
- [ ] Verify GitHub Actions workflow passes with Hugo v0.146.0
- [ ] Verify site deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)